### PR TITLE
Rewrite joystick script for smoother demos

### DIFF
--- a/python_utils/joystick.py
+++ b/python_utils/joystick.py
@@ -1,32 +1,116 @@
+import os
 import sys
 import math
 import time
 import signal
 from xbox360controller import Xbox360Controller
 import utils
-import serial 
+import serial
+from datetime import datetime
 import numpy as np
+import threading
+from glob import glob
 
 import roboteam_embedded_messages.python.REM_BaseTypes as BaseTypes
 from roboteam_embedded_messages.python.REM_RobotCommand import REM_RobotCommand as RobotCommand
 from roboteam_embedded_messages.python.REM_RobotBuzzer import REM_RobotBuzzer as RobotBuzzer
 
-robotCommand = RobotCommand()
-robotBuzzer = RobotBuzzer()
 
-last_written = time.time()
-packet_Hz = 60
-basestation = None
+basestation_handler = None
+joystick_handler = None
+event_handler = None
 
-robot_id = 15
-absolute_angle = 0
 
-KICK_SPEED = 3
+class EventHandler:
+	def __init__(self, shutdown):
+		self.shutdown = shutdown
+		self.running = True
+		self.events = []
 
-class JoystickWrapper:
-	def __init__(self, controller):
+	def start(self, joystick_handler):
+		self.joystick_handler = joystick_handler
+
+		# Start sending in a thread
+		self.thread = threading.Thread(target=self.loop)
+		self.thread.start()
+
+	def record_event(self, id, event):
+		current_time = datetime.now().strftime("%H:%M:%S")
+		id = int(id) + 1
+		self.events.insert(0, f"[{id} | {current_time}] {event}")
+		self.events = self.events[:5]
+
+	def loop(self):
+		try:
+			while self.running:
+				# Clear terminal
+				os.system('cls' if os.name == 'nt' else 'clear')
+
+				for id in self.joystick_handler.controllers:
+					controller = self.joystick_handler.controllers[id]
+					id = int(id) + 1
+					print(f"Controller: {id} | Robot: {controller.robot_id} (Dribbler: {controller.dribbler})")
+				print()
+
+				for event in self.events:
+					print(event)
+				self.events = []
+
+				time.sleep(0.1)
+		except Exception as e:
+			self.event_handler.record_event(-1, e)
+			print(e)
+			self.shutdown()
+
+class JoystickHandler:
+	def __init__(self, event_handler, shutdown):
+		self.shutdown = shutdown
+		self.running = True
+		self.controllers = {}
+		self.lost_controllers = {}
+		self.event_handler = event_handler
+
+		# Start sending in a thread
+		self.thread = threading.Thread(target=self.loop)
+		self.thread.start()
+
+	def loop(self):
+		try:
+			while self.running:
+				# Check if controllers in threads are still alive
+				for id in list(self.controllers.keys()):
+					if not self.controllers[id].controller._event_thread.is_alive():
+						self.event_handler.record_event(id, "Controller disconnected")
+						self.lost_controllers[id] = self.controllers[id].robot_id
+						del self.controllers[id]
+
+				# Discover new controllers that are not paired yet
+				for path in glob("/dev/input/js*"):
+					id = path.replace("/dev/input/js", "")
+					if id not in self.controllers:
+						try:
+							robot_id = self.lost_controllers[id] if id in self.lost_controllers else 0
+							controller = Xbox360Controller(id)
+							wrapper = Joystick(self, controller, robot_id=robot_id)
+							self.controllers[id] = wrapper
+							self.event_handler.record_event(id, "New controller discovered")
+						except Exception as e:
+							print(e)
+							pass
+
+				time.sleep(0.1)
+		except Exception as e:
+			self.event_handler.record_event(-1, e)
+			print(e)
+			self.shutdown()
+
+class Joystick:
+	def __init__(self, joystick_handler, controller, robot_id=0):
+		self.id = controller.index
 		self.controller = controller
-		self.robot_id = 0
+		self.robot_id = robot_id
+		self.kick_speed = 3
+		self.dribbler = False
 		self.absolute_angle = 0
 
 		self.A = False
@@ -37,50 +121,48 @@ class JoystickWrapper:
 		self.HAT_Y = 0
 		self.command = RobotCommand()
 
+		self.assign_open_robot(1)
+
+	def assign_open_robot(self, addition=0):
+		# Skip already claimed ids
+		claimed_ids = []
+		for id in joystick_handler.controllers:
+			if id != self.id:
+				claimed_ids.append(joystick_handler.controllers[id].robot_id)
+		while self.robot_id in claimed_ids:
+			self.robot_id = (self.robot_id + addition) % 16
+
 	def get_payload(self):
-
-		if self.controller.button_mode._value:
-			print("Exiting!")
-			sys.exit()
-
+		# Left or right arrow pressed, loop through available robots
 		if self.HAT_X != self.controller.hat.x:
 			self.HAT_X = self.controller.hat.x
-			self.robot_id += self.controller.hat.x
-			print(f"Switched to ID {self.robot_id}")
+			self.robot_id = (self.robot_id + self.controller.hat.x) % 16
+			self.assign_open_robot(addition=self.controller.hat.x)
 
 		# Toggle dribbler
-		self.command.dribbler = 0
 		if self.controller.button_y._value and not self.Y:
-			self.Y = True
-			if self.command.dribbler == 0: 
-				self.command.dribbler = 7
-			else:
-				self.command.dribbler = 0
-		else:
-			self.Y = False
+			self.dribbler = not self.dribbler
+		self.Y = self.controller.button_y._value
+		self.command.dribbler = self.dribbler
 
-		if self.robot_id < 0: self.robot_id = 0
-		if 15 < self.robot_id : self.robot_id = 15
-
+		# Kick or chip
 		self.command.doKick = False
 		self.command.doChip = False
-
 		if self.controller.button_a._value and not self.A:
-			self.command.kickChipPower = KICK_SPEED
+			self.command.kickChipPower = self.kick_speed
 			self.command.doChip = True
 			self.command.doForce = True
 		self.A = self.controller.button_a._value
 
 		if self.controller.button_b._value and not self.B:
-			self.command.kickChipPower = KICK_SPEED
+			self.command.kickChipPower = self.kick_speed
 			self.command.doKick = True
 			self.command.doForce = True
 		self.B = self.controller.button_b._value
 
-
-		# Angle
+		# Calculate angle
 		if 0.3 < abs(self.controller.axis_r.x): self.absolute_angle -= self.controller.axis_r.x * 0.1
-		
+
 		# Forward backward left right
 		deadzone = 0.3
 
@@ -105,7 +187,6 @@ class JoystickWrapper:
 		self.command.theta = theta + self.absolute_angle
 		self.command.angle = self.absolute_angle
 
-
 		buzzer_value = self.controller.trigger_l._value
 		if 0.3 < buzzer_value:
 			buzzer_command = RobotBuzzer()
@@ -114,56 +195,59 @@ class JoystickWrapper:
 			buzzer_command.id = self.robot_id
 			buzzer_command.period = int(buzzer_value * 1000)
 			buzzer_command.duration = 0.1
-
-			message = self.command.encode()
-			#message = np.concatenate( (self.command.encode(), buzzer_command.encode()) )
-			print(message)
-			return message
+			return buzzer_command.encode()
 
 		return self.command.encode()
 
+class BasestationHandler:
+	def __init__(self, event_handler, joystick_handler, shutdown):
+		self.shutdown = shutdown
+		self.packet_Hz = 60
+		self.running = True
+		self.basestation = utils.openContinuous(timeout=0.001)
+		self.event_handler = event_handler
+		self.joystick_handler = joystick_handler
 
-print(Xbox360Controller.get_available())
+		# Start sending in a thread
+		self.thread = threading.Thread(target=self.loop)
+		self.thread.start()
 
-# wrappers = [JoystickWrapper(Xbox360Controller(i)) for i in range(len(Xbox360Controller.get_available()))]
-wrappers = [JoystickWrapper(controller) for controller in Xbox360Controller.get_available()]
+	def loop(self):
+		try:
+			last_written = time.time()
+			while self.running:
+				if 1./self.packet_Hz <= time.time() - last_written:
+					last_written += 1./self.packet_Hz
 
-while True:
-	# Open basestation with the basestation
-	if basestation is None or not basestation.isOpen():
-		basestation = utils.openContinuous(timeout=0.001)
+					for i in joystick_handler.controllers:
+						self.basestation.write(joystick_handler.controllers[i].get_payload())
 
-	try:
-		while True:
-			# Run at {packet_Hz}fps
-			if 1./packet_Hz <= time.time() - last_written:
-				# Timing stuff
-				last_written += 1./packet_Hz
-				
-				for wrapper in wrappers:
-					basestation.write(wrapper.get_payload())
+				time.sleep(0.005)
+		except Exception as e:
+			self.event_handler.record_event(-1, e)
+			print(e)
+			self.shutdown()
 
-				packet_type = basestation.read(1)
-				if len(packet_type) == 0:
-					continue
+def shutdown():
+	print("Exiting")
+	event_handler.running = False
+	basestation_handler.running = False
+	joystick_handler.running = False
+	for id in joystick_handler.controllers:
+		joystick_handler.controllers[id].controller.close()
 
-				packetType = packet_type[0]
-				
-				if packetType == BaseTypes.PACKET_TYPE_REM_BASESTATION_LOG:
-					logmessage = basestation.readline().decode()
-					print(logmessage)
+event_handler = EventHandler(shutdown)
 
-			time.sleep(0.005)
-		signal.pause()
+def thread_exception_handler(args):
+	event_handler.record_event(-1, f"Caught: {args}")
 
-	except serial.SerialException as se:
-		print("SerialException", se)
-		basestation = None
-	except serial.SerialTimeoutException as ste:
-		print("SerialTimeoutException", ste)
-	except KeyError:
-		print("[Error] KeyError", e, "{0:b}".format(int(str(e))))
-	except Exception as e:
-		print("[Error]", e)
+threading.excepthook = thread_exception_handler
 
-print("Exiting")
+joystick_handler = JoystickHandler(event_handler, shutdown)
+basestation_handler = BasestationHandler(event_handler, joystick_handler, shutdown)
+event_handler.start(joystick_handler)
+
+try:
+	event_handler.thread.join()
+except:
+	shutdown()


### PR DESCRIPTION
The new script does not crash when a controller is disconnected / reconnected, will remember recently assigned robots, and can no longer have two controllers assigned to the same robot. Overall it should make giving a joystick demo a bit more enjoyable