### PR TITLE
Fixed the missing ability to rotate the robot around the axis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .vscode/
 __pycache__
 .idea/
+venv
 Drivers
 Middlewares
 USB_DEVICE

--- a/python_utils/joystick.py
+++ b/python_utils/joystick.py
@@ -186,6 +186,7 @@ class Joystick:
 		self.command.rho = rho
 		self.command.theta = theta + self.absolute_angle
 		self.command.angle = self.absolute_angle
+		self.command.useAbsoluteAngle = 1
 
 		buzzer_value = self.controller.trigger_l._value
 		if 0.3 < buzzer_value:

--- a/python_utils/testRobot.py
+++ b/python_utils/testRobot.py
@@ -9,7 +9,6 @@ import argparse
 import sys 
 import shutil
 import multiprocessing
-from scipy import signal
 
 import utils
 from REMParser import REMParser


### PR DESCRIPTION
The robot did not rotate around its own axis since, the joystick script was no longer compatible with the latest REM version.

The default setting for "useAbsoluteAngle" was by default off, which is now on

Signed-off-by: Tom Meulenkamp <t.meulenkamp@roboteamtwente.nl>