### PR TITLE
Allow support for remotely killing a robot

### DIFF
--- a/Core/Inc/Utilities/packet_buffers.h
+++ b/Core/Inc/Utilities/packet_buffers.h
@@ -14,6 +14,7 @@
 #include "REM_RobotSetPIDGains.h"
 #include "REM_RobotPIDGains.h"
 #include "REM_RobotMusicCommand.h"
+#include "REM_RobotKillCommand.h"
 
 REM_SX1280FillerPayload SX1280_filler_payload;
 
@@ -29,10 +30,15 @@ typedef struct _wrapper_REM_RobotFeedback {
 	bool isNewPacket;
 } wrapper_REM_RobotFeedback;
 
+typedef struct _wrapper_REM_RobotKillCommand {
+	REM_RobotKillCommandPayload packet;
+	bool isNewPacket;
+} wrapper_REM_RobotKillCommand;
 
 
 wrapper_REM_RobotCommand buffer_REM_RobotCommand[MAX_NUMBER_OF_ROBOTS];
 wrapper_REM_RobotFeedback buffer_REM_RobotFeedback[MAX_NUMBER_OF_ROBOTS];
+wrapper_REM_RobotKillCommand buffer_REM_RobotKillCommand[MAX_NUMBER_OF_ROBOTS];
 
 CircularBuffer* nonpriority_queue_robots_index[MAX_NUMBER_OF_ROBOTS];
 CircularBuffer* nonpriority_queue_pc_index;

--- a/python_utils/killRobot.py
+++ b/python_utils/killRobot.py
@@ -7,17 +7,16 @@ from roboteam_embedded_messages.python.REM_BasestationConfiguration import REM_B
 
 connection = utils.openContinuous(timeout=0.01)
 
-def generate_command(int: robot_id) -> REM_RobotKillCommand:
+def generate_command(robot_id: int) -> REM_RobotKillCommand:
 	cmd = REM_RobotKillCommand()
 	cmd.header = BaseTypes.REM_PACKET_TYPE_REM_ROBOT_KILL_COMMAND
 	cmd.toRobotId = robot_id
 	cmd.fromPC = True	
 	cmd.remVersion = BaseTypes.REM_LOCAL_VERSION
-	cmd.messageId = tick_counter
 	cmd.payloadSize = BaseTypes.REM_PACKET_SIZE_REM_ROBOT_KILL_COMMAND
 	return cmd
 
-def generate_basestation_command(bool: yellow) -> REM_BasestationConfiguration:
+def generate_basestation_command(yellow: bool) -> REM_BasestationConfiguration:
 	cmd = REM_BasestationConfiguration()
 	cmd.header = BaseTypes.REM_PACKET_TYPE_REM_BASESTATION_CONFIGURATION
 	cmd.toBS = True
@@ -28,21 +27,10 @@ def generate_basestation_command(bool: yellow) -> REM_BasestationConfiguration:
 	return cmd
 
 while True:
-
-	for robot_id in range(16):
-
-		# Send on the yellow channel
-		bs_cmd = generate_basestation_command(True)
-		connection.write(bs_cmd)
-		cmd = generate_command(robot_id)
-		connection.write(cmd.encode())
-
-	for robot_id in range(16):
-
-		# Send on the blue channel
-		bs_cmd = generate_basestation_command(False)
-		connection.write(bs_cmd)
-		cmd = generate_command(robot_id)
-		connection.write(cmd.encode())
-
+	for team in [True, False]:
+		bs_cmd = generate_basestation_command(team)
+		connection.write(bs_cmd.encode())
+		for robot_id in range(16):
+			cmd = generate_command(robot_id)
+			connection.write(cmd.encode())
 	time.sleep(0.1)

--- a/python_utils/killRobot.py
+++ b/python_utils/killRobot.py
@@ -1,0 +1,48 @@
+import utils
+import time
+
+import roboteam_embedded_messages.python.REM_BaseTypes as BaseTypes
+from roboteam_embedded_messages.python.REM_RobotKillCommand import REM_RobotKillCommand
+from roboteam_embedded_messages.python.REM_BasestationConfiguration import REM_BasestationConfiguration
+
+connection = utils.openContinuous(timeout=0.01)
+
+def generate_command(int: robot_id) -> REM_RobotKillCommand:
+	cmd = REM_RobotKillCommand()
+	cmd.header = BaseTypes.REM_PACKET_TYPE_REM_ROBOT_KILL_COMMAND
+	cmd.toRobotId = robot_id
+	cmd.fromPC = True	
+	cmd.remVersion = BaseTypes.REM_LOCAL_VERSION
+	cmd.messageId = tick_counter
+	cmd.payloadSize = BaseTypes.REM_PACKET_SIZE_REM_ROBOT_KILL_COMMAND
+	return cmd
+
+def generate_basestation_command(bool: yellow) -> REM_BasestationConfiguration:
+	cmd = REM_BasestationConfiguration()
+	cmd.header = BaseTypes.REM_PACKET_TYPE_REM_BASESTATION_CONFIGURATION
+	cmd.toBS = True
+	cmd.fromPC = True
+	cmd.remVersion = BaseTypes.REM_LOCAL_VERSION
+	cmd.payloadSize = BaseTypes.REM_PACKET_SIZE_REM_BASESTATION_CONFIGURATION
+	cmd.channel = yellow
+	return cmd
+
+while True:
+
+	for robot_id in range(16):
+
+		# Send on the yellow channel
+		bs_cmd = generate_basestation_command(True)
+		connection.write(bs_cmd)
+		cmd = generate_command(robot_id)
+		connection.write(cmd.encode())
+
+	for robot_id in range(16):
+
+		# Send on the blue channel
+		bs_cmd = generate_basestation_command(False)
+		connection.write(bs_cmd)
+		cmd = generate_command(robot_id)
+		connection.write(cmd.encode())
+
+	time.sleep(0.1)

--- a/python_utils/testRobot.py
+++ b/python_utils/testRobot.py
@@ -61,7 +61,7 @@ def normalize_angle(angle):
 	if (angle > math.pi): angle -= pi2
 	return angle
 
-testsAvailable = ["nothing", "full", "kicker-reflect", "kicker", "chipper", "dribbler", "rotate", "forward", "sideways", "rotate-discrete", "forward-rotate", "getpid", "angular-velocity", "circle", "raised-cosine", "forward-always", "sideways-always"]
+testsAvailable = ["nothing", "full", "kicker-reflect", "kicker", "chipper", "dribbler", "rotate", "forward", "sideways", "rotate-discrete", "forward-rotate", "getpid", "angular-velocity", "circle", "raised-cosine", "forward-always", "sideways-always", "kill-robot"]
 
 parser = argparse.ArgumentParser()
 parser.add_argument('robot_id', help='Robot ID to send commands to', type=int)


### PR DESCRIPTION
Robots are not supposed to move when they do not receive any commands anymore. However, sometimes this is not always the case...

Hence it is a good idea to remotely turn of a robot in case of an emergency. This PR gives the ability to the base station to send out these commands with priority. It also includes a kill python script for demonstration purposes.

The corresponding PR for REM: RoboTeamTwente/roboteam_embedded_messages#17
The corresponding PR for robot: RoboTeamTwente/roboteam_microcontroller5.0#91