### PR TITLE
Fix robot feedback over usb

### DIFF
--- a/Core/Src/Utilities/CircularBuffer.c
+++ b/Core/Src/Utilities/CircularBuffer.c
@@ -105,7 +105,7 @@ bool CircularBuffer_write(CircularBuffer* circBuf, uint8_t* data, uint32_t lengt
 
     if(!writeAhead1 && !writeAhead2 &&  wrappedAround) overflow = true; // Case 2
     if(!writeAhead1 &&  writeAhead2 && !wrappedAround) overflow = true; // Case 3
-    if(!writeAhead1 &&  writeAhead2 && !wrappedAround) overflow = true; // Case 4
+    if(!writeAhead1 &&  writeAhead2 &&  wrappedAround) overflow = true; // Case 4
     if( writeAhead1 &&  writeAhead2 &&  wrappedAround) overflow = true; // Case 8
 
     return overflow;
@@ -156,14 +156,14 @@ bool CircularBuffer_read(CircularBuffer* circBuf, uint8_t* buffer, uint32_t leng
      *8   true    |     true   |       true   | overrun         ......W...R. => ......W.R... => enough bytes requested to wrap around and pass Write.
     */
 
-    // Update indexWrite
+    // Update indexRead
     circBuf->indexRead = (circBuf->indexRead + length) % circBuf->bufferSize;
     // Used for overrun detection
     bool readAhead2 = circBuf->indexWrite < circBuf->indexRead;
 
     if(!readAhead1 && !readAhead2 &&  wrappedAround) overrun = true; // Case 2
     if(!readAhead1 &&  readAhead2 && !wrappedAround) overrun = true; // Case 3
-    if(!readAhead1 &&  readAhead2 && !wrappedAround) overrun = true; // Case 4
+    if(!readAhead1 &&  readAhead2 &&  wrappedAround) overrun = true; // Case 4
     if( readAhead1 &&  readAhead2 &&  wrappedAround) overrun = true; // Case 8
 
     return overrun;

--- a/Core/Src/basestation.c
+++ b/Core/Src/basestation.c
@@ -23,18 +23,6 @@
 volatile uint32_t packet_counter_in[REM_TOTAL_NUMBER_OF_PACKETS];
 volatile uint32_t packet_counter_out[REM_TOTAL_NUMBER_OF_PACKETS]; 
 
-
-/* Counters, tracking the number of packets handled */ 
-volatile int handled_RobotCommand = 0;
-volatile int handled_RobotFeedback = 0;
-volatile int handled_RobotBuzzer = 0;
-volatile int handled_RobotStateInfo = 0;
-volatile int handled_RobotGetPIDGains = 0;
-volatile int handled_RobotSetPIDGains = 0;
-volatile int handled_RobotPIDGains = 0;
-volatile int handled_RobotMusicCommand = 0;
-volatile int handled_RobotKillCommand = 0;
-
 /* Import hardware handles from main.c */
 extern SPI_HandleTypeDef hspi1;
 extern SPI_HandleTypeDef hspi2;
@@ -115,7 +103,7 @@ uint8_t stringbuffer[1024];
 extern UART_HandleTypeDef huart3;
 
 void init(){
-  HAL_Delay(1000); // TODO Why do we have this again? To allow for USB to start up iirc?
+  HAL_Delay(100); // Wait for the USB to connect
   
   LOG_init();
   
@@ -507,7 +495,6 @@ bool handlePackets(uint8_t* packets_buffer, uint32_t packets_buffer_length){
       // Store the message in the RobotCommand buffer. Set flag indicating packet needs to be sent to the robot
       memcpy(buffer_REM_RobotCommand[robot_id].packet.payload, packet, packet_size);
       buffer_REM_RobotCommand[robot_id].isNewPacket = true;
-      handled_RobotCommand++;
     }else
 
     // High priority : Deal with RobotKillCommand packets that are destined for a robot
@@ -516,7 +503,6 @@ bool handlePackets(uint8_t* packets_buffer, uint32_t packets_buffer_length){
       // TODO: Perhaps dedicate a separate buffer for these types of commands.
       memcpy(buffer_REM_RobotKillCommand[robot_id].packet.payload, packet, packet_size);
       buffer_REM_RobotKillCommand[robot_id].isNewPacket = true;
-      handled_RobotKillCommand++;
     }else
 
     // High priority : Deal with RobotFeedback packets that are destined for the PC
@@ -524,7 +510,6 @@ bool handlePackets(uint8_t* packets_buffer, uint32_t packets_buffer_length){
       // Store the message in the RobotFeedback buffer. Set flag indicating packet needs to be sent to the PC
       memcpy(buffer_REM_RobotFeedback[robot_id].packet.payload, packet, packet_size);
       buffer_REM_RobotFeedback[robot_id].isNewPacket = true;
-      handled_RobotFeedback++;
     }else
 
     // Low priority : Deal with any other packet

--- a/Core/Src/logging.c
+++ b/Core/Src/logging.c
@@ -101,17 +101,12 @@ void LOG_send(){
     // Move up the circular buffer
     CircularBuffer_read(buffer_indexer, NULL, 1);
 }
-
 void LOG_sendBlocking(uint8_t* data, uint8_t length){
     USBD_CDC_HandleTypeDef* hcdc = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData;
-    // while(!(hUsbDeviceFS.dev_state == USBD_STATE_CONFIGURED || hUsbDeviceFS.dev_state == USBD_STATE_SUSPENDED));
-	// if (hUsbDeviceFS.dev_state == USBD_STATE_CONFIGURED || hUsbDeviceFS.dev_state == USBD_STATE_SUSPENDED) {
-    // while(hcdc->TxState != 0);
-		// TODO unneccesary memcpy? How about CDC_Transmit_FS(data, length);? 
-		// 	 if CDC_Transmit_FS is blocking, no fear to have 'data' go out of scope.
-		// memcpy(TxBuffer, data, length);
-    CDC_Transmit_FS(data, length);
-	// }
+    if (hUsbDeviceFS.dev_state == USBD_STATE_CONFIGURED || hUsbDeviceFS.dev_state == USBD_STATE_SUSPENDED) {
+        while(hcdc->TxState != 0);  // Wait until the device is ready to transmit
+        CDC_Transmit_FS(data, length);
+    }
 }
 
 bool LOG_sendBuffer(uint8_t* data, uint32_t length, bool blocking){


### PR DESCRIPTION
This fixes the issue of basestation receiving feedback, but not sending it over usb.
This does not fix the BS not receiving feedback from consecutive id's without antenna's. 